### PR TITLE
Upgrade `pdfbox-version` to the latest version (3.0.5) and fix breaking changes

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/ImageMagickThumbnailFilter.java
@@ -14,7 +14,7 @@ import java.io.InputStream;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.dspace.content.Bitstream;
@@ -154,7 +154,7 @@ public abstract class ImageMagickThumbnailFilter extends MediaFilter {
         // same size as the MediaBox if it doesn't exist. Also note that we
         // only need to check the first page, since that's what we use for
         // generating the thumbnail (PDDocument uses a zero-based index).
-        PDPage pdfPage = PDDocument.load(f).getPage(0);
+        PDPage pdfPage = Loader.loadPDF(f).getPage(0);
         PDRectangle pdfPageMediaBox = pdfPage.getMediaBox();
         PDRectangle pdfPageCropBox = pdfPage.getCropBox();
 

--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFBoxThumbnail.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFBoxThumbnail.java
@@ -11,6 +11,8 @@ import java.awt.image.BufferedImage;
 import java.io.InputStream;
 
 import org.apache.logging.log4j.Logger;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.encryption.InvalidPasswordException;
 import org.apache.pdfbox.rendering.PDFRenderer;
@@ -71,7 +73,7 @@ public class PDFBoxThumbnail extends MediaFilter {
         BufferedImage buf;
 
         // Render the page image.
-        try ( PDDocument doc = PDDocument.load(source); ) {
+        try (PDDocument doc = Loader.loadPDF(new RandomAccessReadBuffer(source)); ) {
             PDFRenderer renderer = new PDFRenderer(doc);
             buf = renderer.renderImage(0);
         } catch (InvalidPasswordException ex) {

--- a/dspace-api/src/main/java/org/dspace/content/packager/PDFPackager.java
+++ b/dspace-api/src/main/java/org/dspace/content/packager/PDFPackager.java
@@ -18,13 +18,11 @@ import java.util.List;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.logging.log4j.Logger;
+import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.cos.COSDocument;
-import org.apache.pdfbox.io.MemoryUsageSetting;
-import org.apache.pdfbox.io.RandomAccessBufferedFileInputStream;
-import org.apache.pdfbox.io.ScratchFile;
-import org.apache.pdfbox.pdfparser.PDFParser;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentInformation;
+import org.apache.pdfbox.pdmodel.fdf.FDFDocument;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.content.Bitstream;
 import org.dspace.content.BitstreamFormat;
@@ -330,18 +328,8 @@ public class PDFPackager
         COSDocument cos = null;
 
         try {
-            ScratchFile scratchFile = null;
-            try {
-                long useRAM = Runtime.getRuntime().freeMemory() * 80 / 100; // use up to 80% of JVM free memory
-                scratchFile = new ScratchFile(
-                    MemoryUsageSetting.setupMixed(useRAM)); // then fallback to temp file (unlimited size)
-            } catch (IOException ioe) {
-                log.warn("Error initializing scratch file: " + ioe.getMessage());
-            }
-
-            PDFParser parser = new PDFParser(new RandomAccessBufferedFileInputStream(metadata), scratchFile);
-            parser.parse();
-            cos = parser.getDocument();
+            FDFDocument document = Loader.loadFDF(metadata);
+            cos = document.getDocument();
 
             // sanity check: PDFBox breaks on encrypted documents, so give up.
             if (cos.getEncryptionDictionary() != null) {

--- a/dspace-api/src/main/java/org/dspace/disseminate/CitationDocumentServiceImpl.java
+++ b/dspace-api/src/main/java/org/dspace/disseminate/CitationDocumentServiceImpl.java
@@ -23,6 +23,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
@@ -30,6 +32,7 @@ import org.apache.pdfbox.pdmodel.PDPageTree;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.service.AuthorizeService;
 import org.dspace.content.Bitstream;
@@ -304,7 +307,7 @@ public class CitationDocumentServiceImpl implements CitationDocumentService, Ini
             Item item = (Item) bitstreamService.getParentObject(context, bitstream);
             final InputStream inputStream = bitstreamService.retrieve(context, bitstream);
             try {
-                sourceDocument = sourceDocument.load(inputStream);
+                sourceDocument = Loader.loadPDF(new RandomAccessReadBuffer(inputStream));
             } finally {
                 inputStream.close();
             }
@@ -335,9 +338,9 @@ public class CitationDocumentServiceImpl implements CitationDocumentService, Ini
             int xwidth = 550;
             int ygap = 20;
 
-            PDFont fontHelvetica = PDType1Font.HELVETICA;
-            PDFont fontHelveticaBold = PDType1Font.HELVETICA_BOLD;
-            PDFont fontHelveticaOblique = PDType1Font.HELVETICA_OBLIQUE;
+            PDFont fontHelvetica = new PDType1Font(Standard14Fonts.FontName.HELVETICA);
+            PDFont fontHelveticaBold = new PDType1Font(Standard14Fonts.FontName.HELVETICA_BOLD);
+            PDFont fontHelveticaOblique = new PDType1Font(Standard14Fonts.FontName.HELVETICA_OBLIQUE);
             contentStream.setNonStrokingColor(Color.BLACK);
 
             String[][] content = {header1};

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/BitstreamRestControllerIT.java
@@ -55,6 +55,8 @@ import java.util.UUID;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.CharEncoding;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -985,7 +987,7 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
 
         try (ByteArrayInputStream source = new ByteArrayInputStream(content);
              Writer writer = new StringWriter();
-             PDDocument pdfDoc = PDDocument.load(source)) {
+             PDDocument pdfDoc = Loader.loadPDF(new RandomAccessReadBuffer(source))) {
 
             pts.writeText(pdfDoc, writer);
             return writer.toString();
@@ -994,7 +996,7 @@ public class BitstreamRestControllerIT extends AbstractControllerIntegrationTest
 
     private int getNumberOfPdfPages(byte[] content) throws IOException {
         try (ByteArrayInputStream source = new ByteArrayInputStream(content);
-             PDDocument pdfDoc = PDDocument.load(source)) {
+             PDDocument pdfDoc = Loader.loadPDF(new RandomAccessReadBuffer(source))) {
             return pdfDoc.getNumberOfPages();
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <!-- NOTE: Jetty needed for Solr, Handle Server & tests -->
         <jetty.version>9.4.57.v20241219</jetty.version>
         <log4j.version>2.24.3</log4j.version>
-        <pdfbox-version>2.0.33</pdfbox-version>
+        <pdfbox-version>3.0.5</pdfbox-version>
         <rome.version>1.19.0</rome.version>
         <slf4j.version>2.0.16</slf4j.version>
         <tika.version>2.9.2</tika.version>


### PR DESCRIPTION
1. Upgrade `pdfbox-version` to the latest version (3.0.5) for safety
2. fix all breaking changes to make sure build success


List of changes in this PR:
* change `PDDocument.load(f)` to `Loader.loadPDF(f)`
* change `PDDocument.load(source);` to `Loader.loadPDF(new RandomAccessReadBuffer(source));`
* change `new PDFParser(new RandomAccessBufferedFileInputStream(metadata), scratchFile)` to `Loader.loadFDF(metadata);`
* ` PDFont fontHelvetica = PDType1Font.HELVETICA; ` to ` new PDType1Font(Standard14Fonts.FontName.HELVETICA);`  
* `PDFont fontHelveticaBold = PDType1Font.HELVETICA_BOLD`; to `new PDType1Font(Standard14Fonts.FontName.HELVETICA_BOLD);`
* `PDFont fontHelveticaOblique = PDType1Font.HELVETICA_OBLIQUE;` to `new PDType1Font(Standard14Fonts.FontName.HELVETICA_OBLIQUE);` 



Finally, we `mvn clean package` and all build failures are fixed.
