### PR TITLE
Add additional stats data processing scripts and methods

### DIFF
--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/UsageReportUtils.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/UsageReportUtils.java
@@ -21,6 +21,8 @@ import org.dspace.app.rest.model.UsageReportPointDateRest;
 import org.dspace.app.rest.model.UsageReportPointDsoTotalVisitsRest;
 import org.dspace.app.rest.model.UsageReportRest;
 import org.dspace.content.Bitstream;
+import org.dspace.content.Collection;
+import org.dspace.content.Community;
 import org.dspace.content.DSpaceObject;
 import org.dspace.content.Item;
 import org.dspace.content.Site;
@@ -52,8 +54,13 @@ public class UsageReportUtils {
     public static final String TOTAL_VISITS_REPORT_ID = "TotalVisits";
     public static final String TOTAL_VISITS_PER_MONTH_REPORT_ID = "TotalVisitsPerMonth";
     public static final String TOTAL_DOWNLOADS_REPORT_ID = "TotalDownloads";
+    public static final String TOTAL_DOWNLOADS_PER_MONTH_REPORT_ID = "TotalDownloadsPerMonth";
     public static final String TOP_COUNTRIES_REPORT_ID = "TopCountries";
     public static final String TOP_CITIES_REPORT_ID = "TopCities";
+    public static final String TOP_ITEMS_REPORT_ID = "TopItems";
+    public static final String TOP_BITSTREAMS_REPORT_ID = "TopBitstreams";
+    public static final String TOTAL_VISITS_ITEMS_REPORT_ID = "TotalVisitsItems";
+    public static final String TOTAL_DOWNLOADS_BITSTREAMS_REPORT_ID = "TotalDownloadsBitstreams";
 
     /**
      * Get list of usage reports that are applicable to the DSO (of given UUID)
@@ -72,11 +79,18 @@ public class UsageReportUtils {
         } else {
             usageReports.add(this.createUsageReport(context, dso, TOTAL_VISITS_REPORT_ID));
             usageReports.add(this.createUsageReport(context, dso, TOTAL_VISITS_PER_MONTH_REPORT_ID));
+            usageReports.add(this.createUsageReport(context, dso, TOTAL_DOWNLOADS_PER_MONTH_REPORT_ID));
             usageReports.add(this.createUsageReport(context, dso, TOP_COUNTRIES_REPORT_ID));
             usageReports.add(this.createUsageReport(context, dso, TOP_CITIES_REPORT_ID));
         }
         if (dso instanceof Item || dso instanceof Bitstream) {
             usageReports.add(this.createUsageReport(context, dso, TOTAL_DOWNLOADS_REPORT_ID));
+        }
+        if (dso instanceof Community || dso instanceof Collection) {
+            usageReports.add(this.createUsageReport(context, dso, TOP_ITEMS_REPORT_ID));
+            usageReports.add(this.createUsageReport(context, dso, TOP_BITSTREAMS_REPORT_ID));
+            usageReports.add(this.createUsageReport(context, dso, TOTAL_VISITS_ITEMS_REPORT_ID));
+            usageReports.add(this.createUsageReport(context, dso, TOTAL_DOWNLOADS_BITSTREAMS_REPORT_ID));
         }
         return usageReports;
     }
@@ -107,6 +121,10 @@ public class UsageReportUtils {
                     usageReportRest = resolveTotalDownloads(context, dso);
                     usageReportRest.setReportType(TOTAL_DOWNLOADS_REPORT_ID);
                     break;
+                case TOTAL_DOWNLOADS_PER_MONTH_REPORT_ID:
+                    usageReportRest = resolveTotalDownloadsPerMonth(context, dso);
+                    usageReportRest.setReportType(TOTAL_DOWNLOADS_PER_MONTH_REPORT_ID);
+                    break;
                 case TOP_COUNTRIES_REPORT_ID:
                     usageReportRest = resolveTopCountries(context, dso);
                     usageReportRest.setReportType(TOP_COUNTRIES_REPORT_ID);
@@ -115,10 +133,27 @@ public class UsageReportUtils {
                     usageReportRest = resolveTopCities(context, dso);
                     usageReportRest.setReportType(TOP_CITIES_REPORT_ID);
                     break;
+                case TOP_ITEMS_REPORT_ID:
+                    usageReportRest = resolveTopItems(context, dso);
+                    usageReportRest.setReportType(TOP_ITEMS_REPORT_ID);
+                    break;
+                case TOP_BITSTREAMS_REPORT_ID:
+                    usageReportRest = resolveTopBitstreams(context, dso);
+                    usageReportRest.setReportType(TOP_BITSTREAMS_REPORT_ID);
+                    break;
+                case TOTAL_VISITS_ITEMS_REPORT_ID:
+                    usageReportRest = resolveTotalVisitsItems(context, dso);
+                    usageReportRest.setReportType(TOTAL_VISITS_ITEMS_REPORT_ID);
+                    break;
+                case TOTAL_DOWNLOADS_BITSTREAMS_REPORT_ID:
+                    usageReportRest = resolveTotalDownloadsBitstreams(context, dso);
+                    usageReportRest.setReportType(TOTAL_DOWNLOADS_BITSTREAMS_REPORT_ID);
+                    break;
                 default:
                     throw new ResourceNotFoundException("The given report id can't be resolved: " + reportId + "; " +
-                                                        "available reports: TotalVisits, TotalVisitsPerMonth, " +
-                                                        "TotalDownloads, TopCountries, TopCities");
+                                                        "available reports: TotalVisits, TotalVisitsPerMonth, TotalDownloadsPerMonth, " +
+                                                        "TotalDownloads, TopCountries, TopCities" +
+                                                        "TopBitstreams, totalVisitsItems, totalDownloadsBitstreams");
             }
             usageReportRest.setId(dso.getID() + "_" + reportId);
             return usageReportRest;
@@ -196,7 +231,7 @@ public class UsageReportUtils {
 
     /**
      * Create a stat usage report for the amount of TotalVisitPerMonth on a DSO, containing one point for each month
-     * with the views on that DSO in that month with the range -6 months to now. If there are no views on the DSO
+     * with the views on that DSO in that month with the range -5 months to now. If there are no views on the DSO
      * in a month, the point on that month contains views=0.
      *
      * @param context DSpace context
@@ -208,7 +243,7 @@ public class UsageReportUtils {
         StatisticsTable statisticsTable = new StatisticsTable(new StatisticsDataVisits(dso));
         DatasetTimeGenerator timeAxis = new DatasetTimeGenerator();
         // TODO month start and end as request para?
-        timeAxis.setDateInterval("month", "-6", "+1");
+        timeAxis.setDateInterval("month", "-5", "+1");
         statisticsTable.addDatasetGenerator(timeAxis);
         DatasetDSpaceObjectGenerator dsoAxis = new DatasetDSpaceObjectGenerator();
         dsoAxis.addDsoChild(dso.getType(), 10, false, -1);
@@ -264,6 +299,54 @@ public class UsageReportUtils {
     }
 
     /**
+     * Create a stat usage report for the amount of TotalDownloadsPerMonth on a DSO, containing one point for each month
+     * with the views on that DSO in that month with the range -5 months to now. If there are no views on the DSO
+     * in a month, the point on that month contains views=0.
+     *
+     * @param context DSpace context
+     * @param dso     DSO we want usage report with TotalDownloadsPerMonth to the DSO
+     * @return Rest object containing the TotalDownloads usage report on the given DSO
+     */
+    private UsageReportRest resolveTotalDownloadsPerMonth(Context context, DSpaceObject dso)
+        throws SQLException, IOException, ParseException, SolrServerException {
+        if (dso instanceof org.dspace.content.Bitstream) {
+            return this.resolveTotalVisitsPerMonth(context, dso);
+        }
+
+        if (dso instanceof org.dspace.content.Item || dso instanceof Collection || dso instanceof Community) {
+            StatisticsTable statisticsTable = new StatisticsTable(new StatisticsDataVisits(dso));
+            DatasetTimeGenerator timeAxis = new DatasetTimeGenerator();
+            // TODO month start and end as request para?
+            timeAxis.setDateInterval("month", "-5", "+1");
+            statisticsTable.addDatasetGenerator(timeAxis);
+            DatasetDSpaceObjectGenerator dsoAxis = new DatasetDSpaceObjectGenerator();
+            dsoAxis.addDsoChild(Constants.BITSTREAM, -1, false, -1);
+            statisticsTable.addDatasetGenerator(dsoAxis);
+            Dataset dataset = statisticsTable.getDataset(context, 0);
+
+            UsageReportRest usageReportRest = new UsageReportRest();
+            for (int i = 0; i < dataset.getColLabels().size(); i++) {
+                UsageReportPointDateRest monthPoint = new UsageReportPointDateRest();
+                monthPoint.setId(dataset.getColLabelsAttrs().get(i).get("id"));
+                monthPoint.setLabel(dataset.getColLabels().get(i));
+
+                if (dataset.getRowLabels().size() > 0) {
+                    int count = 0;
+                    for (int j = 0; j < dataset.getRowLabels().size(); j++) {
+                        count += Integer.valueOf(dataset.getMatrix()[j][i]);
+                    }
+                    monthPoint.addValue("views", count);
+                } else {
+                    monthPoint.addValue("views", 0);
+                }                
+                usageReportRest.addPoint(monthPoint);
+            }
+            return usageReportRest;
+        }
+        throw new IllegalArgumentException("TotalDownloadsPerMonth report only available for communities, collections, items and bitstreams");
+    }
+
+    /**
      * Create a stat usage report for the TopCountries that have visited the given DSO. If there have been no visits, or
      * no visits with a valid Geolite determined country (based on IP), this report contains an empty list of points=[].
      * The list of points is limited to the top 100 countries, and each point contains the country name, its iso code
@@ -309,6 +392,168 @@ public class UsageReportUtils {
             usageReportRest.addPoint(cityPoint);
         }
         return usageReportRest;
+    }
+
+    /**
+     * Create stat usage report of the items most popular over a DSO container (Community or Collection)
+     *
+     * @param context DSpace context
+     * @param dso DSO container on which we want the TopItems
+     * @return Usage report with top most popular items of dso
+     */
+    private UsageReportRest resolveTopItems(Context context, DSpaceObject dso)
+            throws SQLException, IOException, ParseException, SolrServerException {
+        if (dso instanceof Collection || dso instanceof Community) {
+            //Generate listing with a DSO object base
+            StatisticsListing statListing = new StatisticsListing(new StatisticsDataVisits(dso));
+
+            //Adding filter to get the top 10 items
+            DatasetDSpaceObjectGenerator dsoAxis = new DatasetDSpaceObjectGenerator();
+            dsoAxis.addDsoChild(Constants.ITEM, 10, false, -1);
+            statListing.addDatasetGenerator(dsoAxis);
+
+            Dataset dataset = statListing.getDataset(context, 1);
+
+            UsageReportRest usageReportRest = new UsageReportRest();
+            for (int i = 0; i < dataset.getColLabels().size(); i++) {
+                UsageReportPointDsoTotalVisitsRest totalVisitPoint = new UsageReportPointDsoTotalVisitsRest();
+                totalVisitPoint.setType("item");
+                String urlOfItem = dataset.getColLabelsAttrs().get(i).get("url");
+                if (urlOfItem != null) {
+                    String handle = StringUtils.substringAfterLast(urlOfItem, "handle/");
+                    if (handle != null) {
+                        DSpaceObject item = handleService.resolveToObject(context, handle);
+                        totalVisitPoint.setId(item != null ? item.getID().toString() : urlOfItem);
+                        totalVisitPoint.setLabel(item != null ? item.getName() : urlOfItem);
+                        totalVisitPoint.addValue("views", Integer.valueOf(dataset.getMatrix()[0][i]));
+                        usageReportRest.addPoint(totalVisitPoint);
+                    }
+                }
+            }
+            return usageReportRest;
+        }
+        throw new IllegalArgumentException("TopItems report only available for community and collections");
+    }
+
+    /**
+     * Get total visits usage report over items related a DSO container (Community or Collection)
+     *
+     * @param context DSpace context
+     * @param dso DSO container on which we want the report
+     * @return Usage report with item's visits total
+     */
+    private UsageReportRest resolveTotalVisitsItems(Context context, DSpaceObject dso)
+            throws SQLException, IOException, ParseException, SolrServerException {
+        if (dso instanceof Collection || dso instanceof Community) {
+            //Generate listing with a DSO object base
+            StatisticsListing statListing = new StatisticsListing(new StatisticsDataVisits(dso));
+
+            //Adding filter to get the top 10 items
+            DatasetDSpaceObjectGenerator dsoAxis = new DatasetDSpaceObjectGenerator();
+            dsoAxis.addDsoChild(Constants.ITEM, -1, false, -1);
+            statListing.addDatasetGenerator(dsoAxis);
+
+            Dataset dataset = statListing.getDataset(context, 1);
+
+            UsageReportRest usageReportRest = new UsageReportRest();
+            UsageReportPointDsoTotalVisitsRest totalVisitPoint = new UsageReportPointDsoTotalVisitsRest();
+            totalVisitPoint.setType(StringUtils.substringAfterLast(dso.getClass().getName().toLowerCase(), "."));
+            totalVisitPoint.setId(dso.getID().toString());
+            totalVisitPoint.setLabel(dso.getName());
+            if (dataset.getColLabels().size() > 0) {
+                int count = 0;
+                for (int i = 0; i < dataset.getColLabels().size(); i++) {
+                    count += Integer.valueOf(dataset.getMatrix()[0][i]);
+                }
+                totalVisitPoint.addValue("views", count);
+            } else {
+                totalVisitPoint.addValue("views", 0);
+            }
+
+            usageReportRest.addPoint(totalVisitPoint);
+            return usageReportRest;
+        }
+        throw new IllegalArgumentException("totalVisitsItems report only available for community and collections");
+    }
+
+    /**
+     * Create stat usage report of the bitstream most popular over a DSO container (Community or Collection)
+     *
+     * @param context DSpace context
+     * @param dso DSO container on which we want the TopBitstreams
+     * @return Usage report with top most popular items of dso
+     */
+    private UsageReportRest resolveTopBitstreams(Context context, DSpaceObject dso)
+            throws SQLException, IOException, ParseException, SolrServerException {
+        if (dso instanceof Collection || dso instanceof Community) {
+            //Generate listing with a DSO object base
+            StatisticsListing statListing = new StatisticsListing(new StatisticsDataVisits(dso));
+
+            //Adding filter to get the top 10 bitstreams
+            DatasetDSpaceObjectGenerator dsoAxis = new DatasetDSpaceObjectGenerator();
+            dsoAxis.addDsoChild(Constants.BITSTREAM, 10, false, -1);
+            statListing.addDatasetGenerator(dsoAxis);
+
+            Dataset dataset = statListing.getDataset(context, 1);
+
+            UsageReportRest usageReportRest = new UsageReportRest();
+            for (int i = 0; i < dataset.getColLabels().size(); i++) {
+                UsageReportPointDsoTotalVisitsRest totalDownloadsPoint = new UsageReportPointDsoTotalVisitsRest();
+                totalDownloadsPoint.setType("bitstream");
+
+                totalDownloadsPoint.setId(dataset.getColLabelsAttrs().get(i).get("id"));
+
+                totalDownloadsPoint.setLabel(dataset.getColLabels().get(i) + "("
+                    + "Item: " + dataset.getColLabelsAttrs().get(i).get("item") + ")");
+
+                totalDownloadsPoint.addValue("views", Integer.valueOf(dataset.getMatrix()[0][i]));
+                usageReportRest.addPoint(totalDownloadsPoint);
+            }
+            return usageReportRest;
+        }
+        throw new IllegalArgumentException("TopBitstreams report only available for community and collections");
+    }
+
+    /**
+     * Get total downloads usage report over bitstreams related to a DSO container (Community or Collection)
+     *
+     * @param context DSpace context
+     * @param dso DSO container on which we want the report
+     * @return Usage report with item's visits total
+     */
+    private UsageReportRest resolveTotalDownloadsBitstreams(Context context, DSpaceObject dso)
+            throws SQLException, IOException, ParseException, SolrServerException {
+        if (dso instanceof Collection || dso instanceof Community) {
+            //Generate listing with a DSO object base
+            StatisticsListing statListing = new StatisticsListing(new StatisticsDataVisits(dso));
+
+            //Adding filter to get the top 10 items
+            DatasetDSpaceObjectGenerator dsoAxis = new DatasetDSpaceObjectGenerator();
+            dsoAxis.addDsoChild(Constants.BITSTREAM, -1, false, -1);
+            statListing.addDatasetGenerator(dsoAxis);
+
+            Dataset dataset = statListing.getDataset(context, 1);
+
+            UsageReportRest usageReportRest = new UsageReportRest();
+            UsageReportPointDsoTotalVisitsRest totalVisitPoint = new UsageReportPointDsoTotalVisitsRest();
+            totalVisitPoint.setType(StringUtils.substringAfterLast(dso.getClass().getName().toLowerCase(), "."));
+            totalVisitPoint.setId(dso.getID().toString());
+            totalVisitPoint.setLabel(dso.getName());
+            if (dataset.getColLabels().size() > 0) {
+                int count = 0;
+                for (int i = 0; i < dataset.getColLabels().size(); i++) {
+                    count += Integer.valueOf(dataset.getMatrix()[0][i]);
+                }
+                totalVisitPoint.addValue("views", count);
+            } else {
+                totalVisitPoint.addValue("views", 0);
+            }
+
+            usageReportRest.addPoint(totalVisitPoint);
+            return usageReportRest;
+        }
+        throw new IllegalArgumentException("totalDownloadsBitstreams report only available for community "
+            + "and collections");
     }
 
     /**

--- a/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
+++ b/dspace-server-webapp/src/test/java/org/dspace/app/rest/StatisticsRestRepositoryIT.java
@@ -9,9 +9,13 @@ package org.dspace.app.rest;
 
 import static org.apache.commons.codec.CharEncoding.UTF_8;
 import static org.apache.commons.io.IOUtils.toInputStream;
+import static org.dspace.app.rest.utils.UsageReportUtils.TOP_BITSTREAMS_REPORT_ID;
 import static org.dspace.app.rest.utils.UsageReportUtils.TOP_CITIES_REPORT_ID;
 import static org.dspace.app.rest.utils.UsageReportUtils.TOP_COUNTRIES_REPORT_ID;
+import static org.dspace.app.rest.utils.UsageReportUtils.TOP_ITEMS_REPORT_ID;
+import static org.dspace.app.rest.utils.UsageReportUtils.TOTAL_DOWNLOADS_BITSTREAMS_REPORT_ID;
 import static org.dspace.app.rest.utils.UsageReportUtils.TOTAL_DOWNLOADS_REPORT_ID;
+import static org.dspace.app.rest.utils.UsageReportUtils.TOTAL_VISITS_ITEMS_REPORT_ID;
 import static org.dspace.app.rest.utils.UsageReportUtils.TOTAL_VISITS_PER_MONTH_REPORT_ID;
 import static org.dspace.app.rest.utils.UsageReportUtils.TOTAL_VISITS_REPORT_ID;
 import static org.hamcrest.Matchers.empty;
@@ -77,6 +81,7 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
     @Autowired
     protected AuthorizeService authorizeService;
 
+    private Community parentCommunity;
     private Community communityNotVisited;
     private Community communityVisited;
     private Collection collectionNotVisited;
@@ -107,11 +112,11 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
 
         context.turnOffAuthorisationSystem();
 
-        Community community = CommunityBuilder.createCommunity(context).build();
-        communityNotVisited = CommunityBuilder.createSubCommunity(context, community).build();
-        communityVisited = CommunityBuilder.createSubCommunity(context, community).build();
-        collectionNotVisited = CollectionBuilder.createCollection(context, community).build();
-        collectionVisited = CollectionBuilder.createCollection(context, community).build();
+        parentCommunity = CommunityBuilder.createCommunity(context).build();
+        communityNotVisited = CommunityBuilder.createSubCommunity(context, parentCommunity).build();
+        communityVisited = CommunityBuilder.createSubCommunity(context, parentCommunity).build();
+        collectionNotVisited = CollectionBuilder.createCollection(context, parentCommunity).build();
+        collectionVisited = CollectionBuilder.createCollection(context, parentCommunity).build();
         itemVisited = ItemBuilder.createItem(context, collectionNotVisited).build();
         itemNotVisitedWithBitstreams = ItemBuilder.createItem(context, collectionNotVisited).build();
         bitstreamNotVisited = BitstreamBuilder.createBitstream(context,
@@ -1095,6 +1100,376 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
     }
 
     @Test
+    public void totalVisitsItemsReport_Community_NotVisited() throws Exception {
+        // ** WHEN **
+        // We visit an Item
+        ViewEventRest viewEventRest = new ViewEventRest();
+        viewEventRest.setTargetType("item");
+        viewEventRest.setTargetId(itemVisited.getID());
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        getClient(loggedInToken).perform(post("/api/statistics/viewevents")
+            .content(mapper.writeValueAsBytes(viewEventRest))
+            .contentType(contentType))
+                                .andExpect(status().isCreated());
+
+        // And request that collection's TotalVisits stat report
+        getClient(adminToken).perform(
+            get("/api/statistics/usagereports/" + communityNotVisited.getID() + "_" + TOTAL_VISITS_ITEMS_REPORT_ID))
+                   // ** THEN **
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher.matchUsageReport(
+                           communityNotVisited.getID() + "_" + TOTAL_VISITS_ITEMS_REPORT_ID,
+                           TOTAL_VISITS_ITEMS_REPORT_ID,
+                           List.of(
+                               getExpectedDsoViews(communityNotVisited, 0)
+                           )
+                       )
+                   )));
+    }
+
+    @Test
+    public void totalVisitsItemsReport_Community_Visited() throws Exception {
+        // ** WHEN **
+        // We visit an Item
+        ViewEventRest viewEventRest = new ViewEventRest();
+        viewEventRest.setTargetType("item");
+        viewEventRest.setTargetId(itemVisited.getID());
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        getClient(loggedInToken).perform(post("/api/statistics/viewevents")
+            .content(mapper.writeValueAsBytes(viewEventRest))
+            .contentType(contentType))
+                                .andExpect(status().isCreated());
+
+        // And request that collection's TotalVisits stat report
+        getClient(adminToken).perform(
+            get("/api/statistics/usagereports/" + parentCommunity.getID() + "_" + TOTAL_VISITS_ITEMS_REPORT_ID))
+                   // ** THEN **
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher.matchUsageReport(
+                           parentCommunity.getID() + "_" + TOTAL_VISITS_ITEMS_REPORT_ID,
+                           TOTAL_VISITS_ITEMS_REPORT_ID,
+                           List.of(
+                               getExpectedDsoViews(parentCommunity, 1)
+                           )
+                       )
+                   )));
+    }
+
+    @Test
+    public void totalVisitsItemsReport_Collection_NotVisited() throws Exception {
+        // ** WHEN **
+        // We visit an Item
+        ViewEventRest viewEventRest = new ViewEventRest();
+        viewEventRest.setTargetType("item");
+        viewEventRest.setTargetId(itemVisited.getID());
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        getClient(loggedInToken).perform(post("/api/statistics/viewevents")
+            .content(mapper.writeValueAsBytes(viewEventRest))
+            .contentType(contentType))
+                                .andExpect(status().isCreated());
+
+        // And request that collection's TotalVisits stat report
+        getClient(adminToken).perform(
+            get("/api/statistics/usagereports/" + collectionVisited.getID() + "_" + TOTAL_VISITS_ITEMS_REPORT_ID))
+                   // ** THEN **
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher.matchUsageReport(
+                           collectionVisited.getID() + "_" + TOTAL_VISITS_ITEMS_REPORT_ID,
+                           TOTAL_VISITS_ITEMS_REPORT_ID,
+                           List.of(
+                               getExpectedDsoViews(collectionVisited, 0)
+                           )
+                       )
+                   )));
+    }
+
+    @Test
+    public void totalVisitsItemsReport_Collection_Visited() throws Exception {
+        // ** WHEN **
+        // We visit an Item
+        ViewEventRest viewEventRest = new ViewEventRest();
+        viewEventRest.setTargetType("item");
+        viewEventRest.setTargetId(itemVisited.getID());
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        getClient(loggedInToken).perform(post("/api/statistics/viewevents")
+            .content(mapper.writeValueAsBytes(viewEventRest))
+            .contentType(contentType))
+                                .andExpect(status().isCreated());
+
+        // And request that collection's TotalVisits stat report
+        getClient(adminToken).perform(
+            get("/api/statistics/usagereports/" + collectionNotVisited.getID() + "_" + TOTAL_VISITS_ITEMS_REPORT_ID))
+                   // ** THEN **
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher.matchUsageReport(
+                           collectionNotVisited.getID() + "_" + TOTAL_VISITS_ITEMS_REPORT_ID,
+                           TOTAL_VISITS_ITEMS_REPORT_ID,
+                           List.of(
+                               getExpectedDsoViews(collectionNotVisited, 1)
+                           )
+                       )
+                   )));
+    }
+
+    @Test
+    public void totalDownloadsBitstreamsReport_Community_NotVisited() throws Exception {
+        // ** WHEN **
+        ViewEventRest viewEventRest = new ViewEventRest();
+        viewEventRest.setTargetType("bitstream");
+        viewEventRest.setTargetId(bitstreamVisited.getID());
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        getClient(loggedInToken).perform(post("/api/statistics/viewevents")
+            .content(mapper.writeValueAsBytes(viewEventRest))
+            .contentType(contentType))
+                                .andExpect(status().isCreated());
+
+        // And request that collection's TotalVisits stat report
+        getClient(adminToken).perform(
+            get("/api/statistics/usagereports/" + communityNotVisited.getID() + "_"
+                + TOTAL_DOWNLOADS_BITSTREAMS_REPORT_ID))
+                   // ** THEN **
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher.matchUsageReport(
+                           communityNotVisited.getID() + "_" + TOTAL_DOWNLOADS_BITSTREAMS_REPORT_ID,
+                           TOTAL_DOWNLOADS_BITSTREAMS_REPORT_ID,
+                           List.of(
+                               getExpectedDsoViews(communityNotVisited, 0)
+                           )
+                       )
+                   )));
+    }
+
+    @Test
+    public void totalDownloadsBitstreamsReport_Community_Visited() throws Exception {
+        // ** WHEN **
+        ViewEventRest viewEventRest = new ViewEventRest();
+        viewEventRest.setTargetType("bitstream");
+        viewEventRest.setTargetId(bitstreamVisited.getID());
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        getClient(loggedInToken).perform(post("/api/statistics/viewevents")
+            .content(mapper.writeValueAsBytes(viewEventRest))
+            .contentType(contentType))
+                                .andExpect(status().isCreated());
+
+        // And request that collection's TotalVisits stat report
+        getClient(adminToken).perform(
+            get("/api/statistics/usagereports/" + parentCommunity.getID() + "_"
+                + TOTAL_DOWNLOADS_BITSTREAMS_REPORT_ID))
+                   // ** THEN **
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher.matchUsageReport(
+                           parentCommunity.getID() + "_" + TOTAL_DOWNLOADS_BITSTREAMS_REPORT_ID,
+                           TOTAL_DOWNLOADS_BITSTREAMS_REPORT_ID,
+                           List.of(
+                               getExpectedDsoViews(parentCommunity, 1)
+                           )
+                       )
+                   )));
+    }
+
+    @Test
+    public void totalDownloadsBitstreamsReport_Collection_NotVisited() throws Exception {
+        // ** WHEN **
+        ViewEventRest viewEventRest = new ViewEventRest();
+        viewEventRest.setTargetType("bitstream");
+        viewEventRest.setTargetId(bitstreamVisited.getID());
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        getClient(loggedInToken).perform(post("/api/statistics/viewevents")
+            .content(mapper.writeValueAsBytes(viewEventRest))
+            .contentType(contentType))
+                                .andExpect(status().isCreated());
+
+        // And request that collection's TotalVisits stat report
+        getClient(adminToken).perform(
+            get("/api/statistics/usagereports/" + collectionVisited.getID() + "_"
+                + TOTAL_DOWNLOADS_BITSTREAMS_REPORT_ID))
+                   // ** THEN **
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher.matchUsageReport(
+                           collectionVisited.getID() + "_" + TOTAL_DOWNLOADS_BITSTREAMS_REPORT_ID,
+                           TOTAL_DOWNLOADS_BITSTREAMS_REPORT_ID,
+                           List.of(
+                               getExpectedDsoViews(collectionVisited, 0)
+                           )
+                       )
+                   )));
+    }
+
+    @Test
+    public void totalDownloadsBitstreamsReport_Collection_Visited() throws Exception {
+        // ** WHEN **
+        ViewEventRest viewEventRest = new ViewEventRest();
+        viewEventRest.setTargetType("bitstream");
+        viewEventRest.setTargetId(bitstreamVisited.getID());
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        getClient(loggedInToken).perform(post("/api/statistics/viewevents")
+            .content(mapper.writeValueAsBytes(viewEventRest))
+            .contentType(contentType))
+                                .andExpect(status().isCreated());
+
+        // And request that collection's TotalVisits stat report
+        getClient(adminToken).perform(
+            get("/api/statistics/usagereports/" + collectionNotVisited.getID() + "_"
+                + TOTAL_DOWNLOADS_BITSTREAMS_REPORT_ID))
+                   // ** THEN **
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher.matchUsageReport(
+                           collectionNotVisited.getID() + "_" + TOTAL_DOWNLOADS_BITSTREAMS_REPORT_ID,
+                           TOTAL_DOWNLOADS_BITSTREAMS_REPORT_ID,
+                           List.of(
+                               getExpectedDsoViews(collectionNotVisited, 1)
+                           )
+                       )
+                   )));
+    }
+
+    @Test
+    public void topItemsReport_Community_Visited() throws Exception {
+        // ** WHEN **
+        // We visit an Item
+        ViewEventRest viewEventRest = new ViewEventRest();
+        viewEventRest.setTargetType("item");
+        viewEventRest.setTargetId(itemVisited.getID());
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        getClient(loggedInToken).perform(post("/api/statistics/viewevents")
+            .content(mapper.writeValueAsBytes(viewEventRest))
+            .contentType(contentType))
+                                .andExpect(status().isCreated());
+
+        // And request that collection's TotalVisits stat report
+        getClient(adminToken).perform(
+            get("/api/statistics/usagereports/" + parentCommunity.getID() + "_" + TOP_ITEMS_REPORT_ID))
+                   // ** THEN **
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher.matchUsageReport(
+                           parentCommunity.getID() + "_" + TOP_ITEMS_REPORT_ID,
+                           TOP_ITEMS_REPORT_ID,
+                           List.of(
+                               getExpectedDsoViews(itemVisited, 1)
+                           )
+                       )
+                   )));
+    }
+
+    @Test
+    public void topItemsReport_Collection_Visited() throws Exception {
+        // ** WHEN **
+        // We visit an Item
+        ViewEventRest viewEventRest = new ViewEventRest();
+        viewEventRest.setTargetType("item");
+        viewEventRest.setTargetId(itemVisited.getID());
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        getClient(loggedInToken).perform(post("/api/statistics/viewevents")
+            .content(mapper.writeValueAsBytes(viewEventRest))
+            .contentType(contentType))
+                                .andExpect(status().isCreated());
+
+        // And request that collection's TotalVisits stat report
+        getClient(adminToken).perform(
+            get("/api/statistics/usagereports/" + collectionNotVisited.getID() + "_" + TOP_ITEMS_REPORT_ID))
+                   // ** THEN **
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher.matchUsageReport(
+                           collectionNotVisited.getID() + "_" + TOP_ITEMS_REPORT_ID,
+                           TOP_ITEMS_REPORT_ID,
+                           List.of(
+                               getExpectedDsoViews(itemVisited, 1)
+                           )
+                       )
+                   )));
+    }
+
+    @Test
+    public void topBitstreamsReport_Community_Visited() throws Exception {
+        // ** WHEN **
+        ViewEventRest viewEventRest = new ViewEventRest();
+        viewEventRest.setTargetType("bitstream");
+        viewEventRest.setTargetId(bitstreamVisited.getID());
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        getClient(loggedInToken).perform(post("/api/statistics/viewevents")
+            .content(mapper.writeValueAsBytes(viewEventRest))
+            .contentType(contentType))
+                                .andExpect(status().isCreated());
+
+        // And request that collection's TotalVisits stat report
+        getClient(adminToken).perform(
+            get("/api/statistics/usagereports/" + parentCommunity.getID() + "_" + TOP_BITSTREAMS_REPORT_ID))
+                   // ** THEN **
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher.matchUsageReport(
+                           parentCommunity.getID() + "_" + TOP_BITSTREAMS_REPORT_ID,
+                           TOP_BITSTREAMS_REPORT_ID,
+                           List.of(
+                               getExpectedBitstreamsViews(bitstreamVisited, itemNotVisitedWithBitstreams, 1)
+                           )
+                       )
+                   )));
+    }
+
+    @Test
+    public void topBitstreamsReport_Collection_Visited() throws Exception {
+        // ** WHEN **
+        ViewEventRest viewEventRest = new ViewEventRest();
+        viewEventRest.setTargetType("bitstream");
+        viewEventRest.setTargetId(bitstreamVisited.getID());
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        getClient(loggedInToken).perform(post("/api/statistics/viewevents")
+            .content(mapper.writeValueAsBytes(viewEventRest))
+            .contentType(contentType))
+                                .andExpect(status().isCreated());
+
+        // And request that collection's TotalVisits stat report
+        getClient(adminToken).perform(
+            get("/api/statistics/usagereports/" + collectionNotVisited.getID() + "_" + TOP_BITSTREAMS_REPORT_ID))
+                   // ** THEN **
+                   .andExpect(status().isOk())
+                   .andExpect(jsonPath("$", Matchers.is(
+                       UsageReportMatcher.matchUsageReport(
+                           collectionNotVisited.getID() + "_" + TOP_BITSTREAMS_REPORT_ID,
+                           TOP_BITSTREAMS_REPORT_ID,
+                           List.of(
+                               getExpectedBitstreamsViews(bitstreamVisited, itemNotVisitedWithBitstreams, 1)
+                           )
+                       )
+                   )));
+    }
+
+    @Test
     public void usagereportsSearch_notProperURI_Exception() throws Exception {
         getClient(adminToken).perform(get("/api/statistics/usagereports/search/object?uri=BadUri"))
                    .andExpect(status().is(HttpStatus.BAD_REQUEST.value()));
@@ -1262,6 +1637,30 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
                     TOTAL_VISITS_REPORT_ID,
                     List.of(
                         getExpectedDsoViews(communityVisited, 1)
+                    )
+                ),
+                UsageReportMatcher.matchUsageReport(
+                    communityVisited.getID() + "_" + TOP_ITEMS_REPORT_ID,
+                    TOP_ITEMS_REPORT_ID,
+                    List.of()
+                ),
+                UsageReportMatcher.matchUsageReport(
+                    communityVisited.getID() + "_" + TOP_BITSTREAMS_REPORT_ID,
+                    TOP_BITSTREAMS_REPORT_ID,
+                    List.of()
+                ),
+                UsageReportMatcher.matchUsageReport(
+                    communityVisited.getID() + "_" + TOTAL_VISITS_ITEMS_REPORT_ID,
+                    TOTAL_VISITS_ITEMS_REPORT_ID,
+                    List.of(
+                        getExpectedDsoViews(communityVisited, 0)
+                    )
+                ),
+                UsageReportMatcher.matchUsageReport(
+                    communityVisited.getID() + "_" + TOTAL_DOWNLOADS_BITSTREAMS_REPORT_ID,
+                    TOTAL_DOWNLOADS_BITSTREAMS_REPORT_ID,
+                    List.of(
+                        getExpectedDsoViews(communityVisited, 0)
                     )
                 ),
                 UsageReportMatcher.matchUsageReport(
@@ -1529,10 +1928,10 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
             )));
     }
 
-    // Create expected points from -6 months to now, with given number of views in current month
+    // Create expected points from -5 months to now, with given number of views in current month
     private List<UsageReportPointRest> getListOfVisitsPerMonthsPoints(int viewsLastMonth) {
         List<UsageReportPointRest> expectedPoints = new ArrayList<>();
-        int nrOfMonthsBack = 6;
+        int nrOfMonthsBack = 5;
         Calendar cal = Calendar.getInstance();
         for (int i = 0; i <= nrOfMonthsBack; i++) {
             UsageReportPointDateRest expectedPoint = new UsageReportPointDateRest();
@@ -1557,6 +1956,19 @@ public class StatisticsRestRepositoryIT extends AbstractControllerIntegrationTes
         point.setType(StringUtils.lowerCase(Constants.typeText[dso.getType()]));
         point.setId(dso.getID().toString());
         point.setLabel(dso.getName());
+
+        return point;
+    }
+
+    private UsageReportPointDsoTotalVisitsRest getExpectedBitstreamsViews(DSpaceObject dso,
+                                                                            DSpaceObject itemDso, int views) {
+        UsageReportPointDsoTotalVisitsRest point = new UsageReportPointDsoTotalVisitsRest();
+
+        point.addValue("views", views);
+        point.setType(StringUtils.lowerCase(Constants.typeText[dso.getType()]));
+        point.setId(dso.getID().toString());
+        point.setLabel(dso.getName());
+        point.setLabel(dso.getName() + "(" + "Item: " + itemDso.getName() + ")");
 
         return point;
     }

--- a/dspace/bin/solr-data-update
+++ b/dspace/bin/solr-data-update
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Function to safely delete a directory
+DATA_DIR=/usr/local/dspace-angular/src/assets/data/
+DATA_DIR1=/usr/local/dspace-ui-deploy/dist/server/assets/data
+DATA_DIR2=/usr/local/dspace-ui-deploy/dist/browser/assets/data
+
+if [ -d "$DATA_DIR1" ]; then
+   rm -rf $DATA_DIR1
+fi
+
+if [ -d "$DATA_DIR2" ]; then
+    rm -rf $DATA_DIR2
+fi
+
+if [ ! -d "$DATA_DIR" ]; then
+    echo "Error: Source directory $DATA_DIR does not exist."
+    return 1
+fi
+
+cp -TR "$DATA_DIR" "$DATA_DIR1"
+cp -TR "$DATA_DIR" "$DATA_DIR2"
+
+chown -R tomcat: /usr/local/dspace-ui-deploy/dist
+echo "Data updating process finished."

--- a/dspace/bin/solr-export
+++ b/dspace/bin/solr-export
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+DIR=/usr/local/dspace-angular/src/assets/data
+
+if [ ! -d "$DIR" ]; then
+    mkdir -p $DIR
+    chown -R tomcat:tomcat $DIR
+fi
+
+ 
+# Site pageviews
+curl -g  "http://localhost:8983/solr/statistics/select?indent=on&rows=0&q=type:2+AND+isBot:false&fl=id,latitude,longitude,time,ip,city,countryCode,owningColl&wt=json&omitHeader=true" -o $DIR/site-pageviews.json
+# Site downloads
+curl -g "http://localhost:8983/solr/statistics/select?indent=on&rows=0&q=type:0+AND+isBot:false&fq=-(bundleName:%5B*+TO+*%5D-bundleName:ORIGINAL)&fl=id,latitude,longitude,time,ip,city,countryCode,owningColl&wt=json&omitHeader=true" -o $DIR/site-downloads.json
+
+# Site pageviews 6 months
+curl -g "http://localhost:8983/solr/statistics/select?indent=on&rows=0&facet=true&facet.range=time&facet.range.start=NOW-6MONTH/MONTH&facet.range.end=NOW&facet.range.gap=%2B1MONTH&q=type:2+AND+isBot:false&wt=json&omitHeader=true" -o $DIR/site-pageviews-6months.json
+# Site downloads 6 months
+curl -g "http://localhost:8983/solr/statistics/select?indent=on&rows=0&facet=true&facet.range=time&facet.range.start=NOW-6MONTH/MONTH&facet.range.end=NOW&facet.range.gap=%2B1MONTH&q=type:0+AND+isBot:false&wt=json&omitHeader=true&fq=-(bundleName:%5B*+TO+*%5D-bundleName:ORIGINAL)" -o $DIR/site-downloads-6months.json
+
+# Site country downloads
+curl -g "http://localhost:8983/solr/statistics/select?q=type:0&rows=0&facet.field=countryCode&facet.mincount=1&facet.limit=-1&facet.sort=count&facet=true&fq=isBot:false&indent=true&fq=-(bundleName:%5B*+TO+*%5D-bundleName:ORIGINAL)&omitHeader=true" -o $DIR/site-country-downloads.json
+# Site country views
+curl -g "http://localhost:8983/solr/statistics/select?q=type:2&rows=0&facet.field=countryCode&facet.mincount=1&facet.limit=-1&facet.sort=count&facet=true&fq=isBot:false&indent=true&omitHeader=true" -o $DIR/site-country-views.json
+
+# Site top 10 item pageviews
+curl "http://localhost:8983/solr/statistics/select?q=type:2&rows=0&facet=true&facet.field=id&facet.limit=10&facet.mincount=1&fl=score&fq=isBot:false&fq=statistics_type:view&indent=true&wt=json&omitHeader=true" -o $DIR/site-top10-item-pageviews.json
+# Site top 10 item downloads
+curl "http://localhost:8983/solr/statistics/select?q=type:0&rows=0&facet=true&facet.field=owningItem&facet.limit=10&facet.mincount=1&fq=-(bundleName:%5B*+TO+*%5D-bundleName:ORIGINAL)&fq=isBot:false&indent=true&fl=score&wt=json&omitHeader=true" -o $DIR/site-top10-item-downloads.json
+
+# Site item count
+curl "http://localhost:8983/solr/search/select?q=search.resourcetype:Item&rows=0&indent=on&wt=json&omitHeader=true" -o $DIR/all-item-count.json > /dev/null 2>&1

--- a/dspace/bin/solr-export
+++ b/dspace/bin/solr-export
@@ -24,9 +24,9 @@ curl -g "http://localhost:8983/solr/statistics/select?q=type:0&rows=0&facet.fiel
 curl -g "http://localhost:8983/solr/statistics/select?q=type:2&rows=0&facet.field=countryCode&facet.mincount=1&facet.limit=-1&facet.sort=count&facet=true&fq=isBot:false&indent=true&omitHeader=true" -o $DIR/site-country-views.json
 
 # Site top 10 item pageviews
-curl "http://localhost:8983/solr/statistics/select?q=type:2&rows=0&facet=true&facet.field=id&facet.limit=10&facet.mincount=1&fl=score&fq=isBot:false&fq=statistics_type:view&indent=true&wt=json&omitHeader=true" -o $DIR/site-top10-item-pageviews.json
+curl "http://localhost:8983/solr/statistics/select?q=type:2&rows=0&facet=true&facet.field=id&facet.limit=10&facet.mincount=1&fl=score&fq=isBot:false&fq=statistics_type:view&indent=true&wt=json&omitHeader=true&fq=-(id:*unmigrated)" -o $DIR/site-top10-item-pageviews.json
 # Site top 10 item downloads
-curl "http://localhost:8983/solr/statistics/select?q=type:0&rows=0&facet=true&facet.field=owningItem&facet.limit=10&facet.mincount=1&fq=-(bundleName:%5B*+TO+*%5D-bundleName:ORIGINAL)&fq=isBot:false&indent=true&fl=score&wt=json&omitHeader=true" -o $DIR/site-top10-item-downloads.json
+curl "http://localhost:8983/solr/statistics/select?q=type:0&rows=0&facet=true&facet.field=owningItem&facet.limit=10&facet.mincount=1&fq=-(bundleName:%5B*+TO+*%5D-bundleName:ORIGINAL)&fq=isBot:false&indent=true&fl=score&wt=json&omitHeader=true&fq=-(id:*unmigrated)" -o $DIR/site-top10-item-downloads.json
 
 # Site item count
 curl "http://localhost:8983/solr/search/select?q=search.resourcetype:Item&rows=0&indent=on&wt=json&omitHeader=true" -o $DIR/all-item-count.json > /dev/null 2>&1

--- a/dspace/bin/update-stats
+++ b/dspace/bin/update-stats
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# export-data.sh - Master script to run multiple data loading scripts with pauses and input file handling
+DIRECTORY="/usr/local/dspace/bin"
+DIR=/usr/local/dspace-angular/src/assets/data
+
+# Print a header
+echo "Starting data loading process..."
+
+# Run the first script with input file
+echo "Running solr-export..."
+
+if [ -f "$DIRECTORY/solr-export" ]; then
+    source "$DIRECTORY/solr-export"
+else
+    echo "Error: solr-export not found!"
+    exit 1
+fi
+
+# Update data
+echo "Running solr-data-update..."
+
+if [ -f "$DIRECTORY/solr-data-update" ]; then
+    source "$DIRECTORY/solr-data-update"
+else
+    echo "Error: solr-data-update not found!"
+    exit 1
+fi


### PR DESCRIPTION
## Description

Adds methods to calculate: 
* Top downloads per month for items, collections, and communities
* Top items for communities and collections
* Top bitstreams for communities and collections
* Total aggregated downloads for communities and collections
* Total aggregated views for communities and collections 

Adds bash scripts that:
* Clear existing stats json files
* Uses solr queries to generate json files with aggregated site-level statistics including
  * Site views
  * Site downloads
  * Site views over the past 6 months
  * Site downloads over the past 6 months
  * Site downloads by country
  * Site views by country
  * Top 10 site items by views
  * Top 10 site items by downloads
  * Total items on site


Eventually will need to add additional java tests for the Total Downloads per Month added into `dspace-server-webapp/src/main/java/org/dspace/app/rest/utils/UsageReportUtils.java`. Future tests will be added to `dspace-server-webapp/src/test/java/org/dspace/app/rest/utils/UsageReportUtils.java`.

Based off of https://www.github.com/DSpace/DSpace/pull/10437